### PR TITLE
Specify newline argument when opening csv file

### DIFF
--- a/src/motion_pvt_sequence_generation/pvt.py
+++ b/src/motion_pvt_sequence_generation/pvt.py
@@ -737,7 +737,7 @@ class Sequence:
         # Generate names for each axis
         axis_names = [f"Axis {i + 1}" for i in range(self.dim)]
         # Write the data to the file
-        with open(filename, "w", encoding="utf-8") as file:
+        with open(filename, "w", encoding="utf-8", newline="") as file:
             file_writer = csv.writer(file)
             # Construct header, alternating position and velocity values
             header = ["Time"]


### PR DESCRIPTION
Python recommends specifying the argument `newline=''` when opening a file for CSV writing to prevent Windows from adding an extra return character between lines.

See https://docs.python.org/3/library/csv.html#csv.csvwriter