### PR TITLE
Renames zaber motion binary in pyinstaller

### DIFF
--- a/examples/util_pyinstaller/README.md
+++ b/examples/util_pyinstaller/README.md
@@ -12,7 +12,7 @@ When used with Zaber Motion Library the shared library (.dll, .so, or .dylib) fi
 The command below taken from `build.bat` demonstrates how to include the library.
 
 ```ps1
-pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-lib-windows-amd64.dll;zaber_motion_bindings" main.py
+pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-core-windows-amd64.dll;zaber_motion_bindings" main.py
 ```
 
 ## Dependencies / Software Requirements / Prerequisites

--- a/examples/util_pyinstaller/build.bat
+++ b/examples/util_pyinstaller/build.bat
@@ -1,2 +1,2 @@
 call .venv\Scripts\activate.bat
-pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-lib-windows-amd64.dll;zaber_motion_bindings" main.py
+pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-core-windows-amd64.dll;zaber_motion_bindings" main.py


### PR DESCRIPTION
This will have to be renamed if we update the examples to use zaber motion library v7.