### PR TITLE
Fix pyinstaller example

### DIFF
--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -26,7 +26,7 @@ jobs:
         name: Inspect Examples
         run: |
           python3 -m pip install --user --upgrade pip
-          python3 -m pip install --user --upgrade pipenv
+          python3 -m pip install --user --upgrade pipenv==2024.0.2
           python3 -m pip install --user --upgrade pdm
           cd tools/check_examples
           npm install

--- a/examples/util_pyinstaller/README.md
+++ b/examples/util_pyinstaller/README.md
@@ -37,7 +37,7 @@ pdm install
 pdm run example
 ```
 
-## Building the Executable
+## Building the Executable (Windows)
 
 To build the executable:
 
@@ -52,4 +52,21 @@ You can test it by running:
 
 ```shell
 .\dist\main.exe
+```
+
+## Building the Executable (Linux/macOS)
+
+```shell
+cd examples/util_pyinstaller/
+pdm install
+./build.sh
+```
+
+Note to linux users that you may need to use `sudo`
+
+You'll find the distributable executable `main.exe` in the `dist` directory.
+You can test it by running:
+
+```shell
+./dist/main
 ```

--- a/examples/util_pyinstaller/README.md
+++ b/examples/util_pyinstaller/README.md
@@ -62,9 +62,7 @@ pdm install
 ./build.sh
 ```
 
-Note to linux users that you may need to use `sudo`
-
-You'll find the distributable executable `main.exe` in the `dist` directory.
+You'll find the distributable executable `main` in the `dist` directory.
 You can test it by running:
 
 ```shell

--- a/examples/util_pyinstaller/build.bat
+++ b/examples/util_pyinstaller/build.bat
@@ -1,2 +1,2 @@
 call .venv\Scripts\activate.bat
-pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-core-windows-amd64.dll;zaber_motion_bindings" main.py
+pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-core-windows-amd64.dll;zaber_motion_bindings" src/util_pyinstaller/main.py

--- a/examples/util_pyinstaller/build.bat
+++ b/examples/util_pyinstaller/build.bat
@@ -1,2 +1,2 @@
 call .venv\Scripts\activate.bat
-pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings\zaber-motion-core-windows-amd64.dll;zaber_motion_bindings" src/util_pyinstaller/main.py
+pyinstaller --onefile --add-binary ".venv\Lib\site-packages\zaber_motion_bindings;zaber_motion_bindings" src/util_pyinstaller/main.py

--- a/examples/util_pyinstaller/build.sh
+++ b/examples/util_pyinstaller/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source .venv/bin/activate
+pyinstaller --onefile --add-binary=.venv/lib/python3.11/site-packages/zaber_motion_bindings:zaber_motion_bindings src/util_pyinstaller/main.py
+deactivate

--- a/examples/util_pyinstaller/pdm.lock
+++ b/examples/util_pyinstaller/pdm.lock
@@ -4,8 +4,11 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
-lock_version = "4.4.2"
-content_hash = "sha256:24d3a33fbaaac9344d985cd298a8088043e70db21689a814492b447b4972e0b6"
+lock_version = "4.5.0"
+content_hash = "sha256:122953ca59ea7cb961c09b25f853ddeb0359600333c8bbc77413bd48946e221f"
+
+[[metadata.targets]]
+requires_python = "==3.11.*"
 
 [[package]]
 name = "altgraph"
@@ -23,6 +26,9 @@ version = "3.2.2"
 requires_python = ">=3.8.0"
 summary = "An abstract syntax tree for Python with inference support."
 groups = ["dev"]
+dependencies = [
+    "typing-extensions>=4.0.0; python_version < \"3.11\"",
+]
 files = [
     {file = "astroid-3.2.2-py3-none-any.whl", hash = "sha256:e8a0083b4bb28fcffb6207a3bfc9e5d0a68be951dd7e336d5dcf639c682388c0"},
     {file = "astroid-3.2.2.tar.gz", hash = "sha256:8ead48e31b92b2e217b6c9733a21afafe479d52d6e164dd25fb1a770c7c3cf94"},
@@ -40,6 +46,8 @@ dependencies = [
     "packaging>=22.0",
     "pathspec>=0.9.0",
     "platformdirs>=2",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.0.1; python_version < \"3.11\"",
 ]
 files = [
     {file = "black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474"},
@@ -58,6 +66,7 @@ summary = "Composable command line interface toolkit"
 groups = ["dev"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
+    "importlib-metadata; python_version < \"3.8\"",
 ]
 files = [
     {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
@@ -132,6 +141,7 @@ summary = "Optional static typing for Python"
 groups = ["dev"]
 dependencies = [
     "mypy-extensions>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
     "typing-extensions>=4.1.0",
 ]
 files = [
@@ -207,6 +217,7 @@ requires_python = ">=3.6"
 summary = "Python docstring style checker"
 groups = ["dev"]
 dependencies = [
+    "importlib-metadata<5.0.0,>=2.0.0; python_version < \"3.8\"",
     "snowballstemmer>=2.2.0",
 ]
 files = [
@@ -222,6 +233,7 @@ summary = "PyInstaller bundles a Python application and all its dependencies int
 groups = ["default"]
 dependencies = [
     "altgraph",
+    "importlib-metadata>=4.6; python_version < \"3.10\"",
     "macholib>=1.8; sys_platform == \"darwin\"",
     "packaging>=22.0",
     "pefile>=2022.5.30; sys_platform == \"win32\"",
@@ -251,6 +263,7 @@ requires_python = ">=3.7"
 summary = "Community maintained hooks for PyInstaller"
 groups = ["default"]
 dependencies = [
+    "importlib-metadata>=4.6; python_version < \"3.10\"",
     "packaging>=22.0",
     "setuptools>=42.0.0",
 ]
@@ -268,11 +281,15 @@ groups = ["dev"]
 dependencies = [
     "astroid<=3.3.0-dev0,>=3.2.2",
     "colorama>=0.4.5; sys_platform == \"win32\"",
+    "dill>=0.2; python_version < \"3.11\"",
     "dill>=0.3.6; python_version >= \"3.11\"",
+    "dill>=0.3.7; python_version >= \"3.12\"",
     "isort!=5.13.0,<6,>=4.2.5",
     "mccabe<0.8,>=0.6",
     "platformdirs>=2.2.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
     "tomlkit>=0.10.1",
+    "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 files = [
     {file = "pylint-3.2.5-py3-none-any.whl", hash = "sha256:32cd6c042b5004b8e857d727708720c54a676d1e22917cf1a2df9b4d4868abd6"},
@@ -350,7 +367,7 @@ files = [
 
 [[package]]
 name = "zaber-motion"
-version = "6.4.0"
+version = "7.2.1"
 requires_python = ">=3.8"
 summary = "An official library for communicating with Zaber devices."
 groups = ["default"]
@@ -358,12 +375,12 @@ dependencies = [
     "reactivex~=4.0.0",
 ]
 files = [
-    {file = "zaber_motion-6.4.0-py3-none-macosx_10_4_universal2.whl", hash = "sha256:835736a81a9a4da96ddce7ac6c45e92a934352355374e9b5f247eb1c45e84572"},
-    {file = "zaber_motion-6.4.0-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c09c57b9a881c17a324b81500d099967ceff9eba35e56cddddce75299244cd89"},
-    {file = "zaber_motion-6.4.0-py3-none-manylinux_2_27_armv7l.whl", hash = "sha256:54d2c4a448461f570b96eb6cc9825977434f0f0a54a203b87d15d3497cad1f88"},
-    {file = "zaber_motion-6.4.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:272357f0fe0541bc1479c8978c7998910e8f387f59576a887e81c5bdaf4ed005"},
-    {file = "zaber_motion-6.4.0-py3-none-win32.whl", hash = "sha256:06dd76f0a1677b131e18f3ea05110bd93f33badb4510d0a089a153fe8064f0bd"},
-    {file = "zaber_motion-6.4.0-py3-none-win_amd64.whl", hash = "sha256:003e190b327ce72f967147df77e09a4872714ce4ee2d248cc4e4fe4622e3ba86"},
-    {file = "zaber_motion-6.4.0-py3-none-win_arm64.whl", hash = "sha256:603ee4166f50569eae8d8b4e8da2bbca90bb1db9119d65e531341fddee7be218"},
-    {file = "zaber_motion-6.4.0.tar.gz", hash = "sha256:221f4d749bb0dedd6da657ad40496517e39abb1e6781a54c6f9ba3ded014b187"},
+    {file = "zaber_motion-7.2.1-py3-none-macosx_10_4_universal2.whl", hash = "sha256:3bf68fb5f9e3ebde18180043803fdeb6db6640f5b18f2e890f5cdf5c6523a960"},
+    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:1dfbf56e34b5c33ec4af6a5c25d100badadb324a8782753d17f0c27348d256d8"},
+    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_armv7l.whl", hash = "sha256:2a1b545668b00cf9778e2c839e62df9cf59b33f894ac4a7e4573c6d36777303f"},
+    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:128a7de511ad7194507335c4942449e9dac005983ef9e279776617d1388928be"},
+    {file = "zaber_motion-7.2.1-py3-none-win32.whl", hash = "sha256:21e8a7811d027724945eec142dc7fb8457e1e3f13fa36a323dcd9a1571efde0c"},
+    {file = "zaber_motion-7.2.1-py3-none-win_amd64.whl", hash = "sha256:b6f90a92faf3bf8ca4e052150d8d926c1229283122e41c1380b33a3994d6eb46"},
+    {file = "zaber_motion-7.2.1-py3-none-win_arm64.whl", hash = "sha256:8affa341ce6f8e4c389440b623823f2c88b91ff066ac1ca2f86cc0daa788aace"},
+    {file = "zaber_motion-7.2.1.tar.gz", hash = "sha256:1a17ef16a7ec2d8b7cd503690b801d05a2fd4db2c3627e5ea3b705e100c929db"},
 ]

--- a/examples/util_pyinstaller/pdm.lock
+++ b/examples/util_pyinstaller/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:122953ca59ea7cb961c09b25f853ddeb0359600333c8bbc77413bd48946e221f"
+content_hash = "sha256:232e6c3a555d3288fe443516080d3ef08d2611bd23d7139ef37f9bdb89bb7ee8"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -367,7 +367,7 @@ files = [
 
 [[package]]
 name = "zaber-motion"
-version = "7.2.1"
+version = "7.2.2"
 requires_python = ">=3.8"
 summary = "An official library for communicating with Zaber devices."
 groups = ["default"]
@@ -375,12 +375,12 @@ dependencies = [
     "reactivex~=4.0.0",
 ]
 files = [
-    {file = "zaber_motion-7.2.1-py3-none-macosx_10_4_universal2.whl", hash = "sha256:3bf68fb5f9e3ebde18180043803fdeb6db6640f5b18f2e890f5cdf5c6523a960"},
-    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:1dfbf56e34b5c33ec4af6a5c25d100badadb324a8782753d17f0c27348d256d8"},
-    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_armv7l.whl", hash = "sha256:2a1b545668b00cf9778e2c839e62df9cf59b33f894ac4a7e4573c6d36777303f"},
-    {file = "zaber_motion-7.2.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:128a7de511ad7194507335c4942449e9dac005983ef9e279776617d1388928be"},
-    {file = "zaber_motion-7.2.1-py3-none-win32.whl", hash = "sha256:21e8a7811d027724945eec142dc7fb8457e1e3f13fa36a323dcd9a1571efde0c"},
-    {file = "zaber_motion-7.2.1-py3-none-win_amd64.whl", hash = "sha256:b6f90a92faf3bf8ca4e052150d8d926c1229283122e41c1380b33a3994d6eb46"},
-    {file = "zaber_motion-7.2.1-py3-none-win_arm64.whl", hash = "sha256:8affa341ce6f8e4c389440b623823f2c88b91ff066ac1ca2f86cc0daa788aace"},
-    {file = "zaber_motion-7.2.1.tar.gz", hash = "sha256:1a17ef16a7ec2d8b7cd503690b801d05a2fd4db2c3627e5ea3b705e100c929db"},
+    {file = "zaber_motion-7.2.2-py3-none-macosx_10_4_universal2.whl", hash = "sha256:a7bee4afe5c09cd8948544318540fc3c26fad33a97d7ec14f3c32e906145a433"},
+    {file = "zaber_motion-7.2.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:93a564c133aca595443335c90ac79f413c7ea0587254c66573fc0bcd5e92642b"},
+    {file = "zaber_motion-7.2.2-py3-none-manylinux_2_27_armv7l.whl", hash = "sha256:c530b245888ea874508881a249b489bc12c98dde46116fcff54b2d121d47d0a5"},
+    {file = "zaber_motion-7.2.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:5c7555f9459b738feb3c1909e220c2bff7e1de3c3110d39474fbd8cee80d4b1d"},
+    {file = "zaber_motion-7.2.2-py3-none-win32.whl", hash = "sha256:1e208d42b18501c099ea28526cf43512d1ab5d952b887507cf628ced19196cc3"},
+    {file = "zaber_motion-7.2.2-py3-none-win_amd64.whl", hash = "sha256:6fe545e1937b853253f12e7ad3b563f7b7fff968c6710efc8250bb92d9fdda16"},
+    {file = "zaber_motion-7.2.2-py3-none-win_arm64.whl", hash = "sha256:65edb06cbbba6f7c36b5575f392c2efad1585b297355a1c8c5637eba868b07d3"},
+    {file = "zaber_motion-7.2.2.tar.gz", hash = "sha256:29b1d19fd7522f19a133712247bacd4c8b33e51b20cc28607e505e53ac28164d"},
 ]

--- a/examples/util_pyinstaller/pyproject.toml
+++ b/examples/util_pyinstaller/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "pyinstaller==6.5.0",
-    "zaber-motion>=7.2.1",
+    "zaber-motion==7.2.2",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"

--- a/examples/util_pyinstaller/pyproject.toml
+++ b/examples/util_pyinstaller/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "Martin Zak", email = "software@zaber.com"},
 ]
 dependencies = [
-    "zaber-motion==6.4.0",
     "pyinstaller==6.5.0",
+    "zaber-motion>=7.2.1",
 ]
 requires-python = "==3.11.*"
 readme = "README.md"


### PR DESCRIPTION
Add bash build script and documentation for linux/macOS users.
Fix build.bat script for windows.
Update zml version to normalize go lib load path.