### PR TITLE
Unifies all code snippet link styles

### DIFF
--- a/docs/readme-guidelines.md
+++ b/docs/readme-guidelines.md
@@ -15,8 +15,11 @@ explanation of the theory, and intent behind the central concept of the code to 
 
 `README.md` is written in [GitHub's flavour of Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
-There are some cool features, such as the ability to insert [permanent links to code snippets](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet)
-directly in the document.
+To insert a [link to a code snippet](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet), link to a specific commit and not to a branch. Also, enclose the link in angle brackets. For example:
+
+```
+<https://github.com/zabertech/zaber-examples/blob/9b7440e22bfcfd4096441dc03ddff4fd122cb0a4/examples/motion_tracking/src/motion_tracking/main.py#L17-L32>
+```
 
 - Note: if the code is changed in a subsequent commit, be sure to update the permanent link to the latest commit
 (requires a second, separate commit to update README.md).

--- a/examples/microscope_autofocus/README.md
+++ b/examples/microscope_autofocus/README.md
@@ -47,6 +47,7 @@ There are also a number of optional parameters:
 First, it will initialize the motor and camera:
 
 <https://github.com/zabertech/zaber-examples/blob/04150a1fee2df1fa43c6d06df728f61cc12c59ba/src/microscope_autofocus/autofocus.py#L90-L94>
+
 In the example code, I'll be using the following pyspin and ZML functions:
 
 - `cam.get_array`: returns an image from the camera in a format that OpenCV can use

--- a/examples/microscope_high_throughput_scanning/README.md
+++ b/examples/microscope_high_throughput_scanning/README.md
@@ -37,6 +37,7 @@ see [Find the right serial port name](https://software.zaber.com/motion-library/
 
 Enter your scan protocol in `config.py`:
 <https://github.com/zabertech/zaber-examples/blob/04150a1fee2df1fa43c6d06df728f61cc12c59ba/src/microscope_high_throughput_scanning/config.py#L37-L44>
+
 These settings define the dimension and position of your sample as well as the magnification. There are three modes:
 
 - `TDI`: Triggering is done using onboard triggers and the TDI calculator as described in our [TDI imaging article](https://www.zaber.com/articles/tdi-imaging). This generates a snaking motion profile which will scan the sample based on the exposure required limited to the maximum stage speed.
@@ -51,6 +52,7 @@ Enter the details of your camera in `CAMERAS` as shown below:
 1. Using the joystick, record the stage origin such that the edge of the camera FOV meets the edge of the scan area (blue square). Enter this as `origin`
 2. Select the COM port to use to connect to your Zaber devices and choose your scan protocol and camera.
 <https://github.com/zabertech/zaber-examples/blob/04150a1fee2df1fa43c6d06df728f61cc12c59ba/src/microscope_high_throughput_scanning/microscope_hts.py#L18-L21>
+
 3. Call `generate_snake(PROTOCOL, scanning_speed)` to determine the fastest scan direction for your sample and store the motion instructions onto the stage
 4. Call `execute_scan()` to move to the origin and start scanning your sample! On subsequent runs you can repeatedly call this without re-doing the setup steps above.
 

--- a/examples/motion_tracking/README.md
+++ b/examples/motion_tracking/README.md
@@ -38,7 +38,7 @@ pdm run example
 
 ### Explanation
 
-https://github.com/zabertech/zaber-examples/blob/main/examples/motion_tracking/src/motion_tracking/main.py#L17-L32
+<https://github.com/zabertech/zaber-examples/blob/9b7440e22bfcfd4096441dc03ddff4fd122cb0a4/examples/motion_tracking/src/motion_tracking/main.py#L17-L32>
 
 After establishing a connection with the device, the script prints the PI controller parameters.
 


### PR DESCRIPTION
- Modifies all code snippet links to be enclosed in angle brackets for compatibility with website Markdown rendering
- Changes one code snippet link to point to specific commit instead of branch
- Updates documentation with instructions for authors of code examples

Part of SG-353