### PR TITLE
Fix text styling for MATLAB Article

### DIFF
--- a/examples/util_matlab_compiler/README.md
+++ b/examples/util_matlab_compiler/README.md
@@ -63,4 +63,4 @@ cd examples/util_matlab_compiler
 ./ZaberTestApp/output/build/run_ZaberTestApp.sh <deployedMcrRoot>
 ```
 
-Where <deployedMcrRoot> is the path to your MATLAB install.
+Where `<deployedMcrRoot>` is the path to your MATLAB install.


### PR DESCRIPTION
Markdown renderer is interpreting angle braces as html