### PR TITLE
Readme clarification

### DIFF
--- a/examples/self_test_direct_encoder_stage/README.md
+++ b/examples/self_test_direct_encoder_stage/README.md
@@ -2,13 +2,13 @@
 
 *By Nathan Paolini*
 
-These are scripts that can be run to allow a Zaber stage with a Direct Encoder (DE) to analyze its own performance.
+These are scripts that can be run to allow a Zaber stage with a direct encoder to analyze its own performance.
 
 ![accuracy_plot.png](img/accuracy_plot.png)
 
 ## Hardware Requirements
 
-A linear or rotary DE stage.
+A linear or rotary direct encoder stage.
 
 ## Dependencies / Software Requirements / Prerequisites
 
@@ -50,5 +50,5 @@ pdm run settling-time
 
 Zaber stages with direct encoders allow the stage to report on its own performance.
 
-- `src/self_test_direct_encoder_stage/accuracy.py` allows a DE stage to test it's open loop accuracy or repeatability.
-- `src/self_test_direct_encoder_stage/settling_time.py` allows a DE stage to determine its move-and-settle time for a variety of settings and step sizes.
+- `src/self_test_direct_encoder_stage/accuracy.py` allows a direct encoder stage to test it's open loop accuracy or repeatability.
+- `src/self_test_direct_encoder_stage/settling_time.py` allows a direct encoder stage to determine its move-and-settle time for a variety of settings and step sizes.

--- a/examples/self_test_direct_encoder_stage/README.md
+++ b/examples/self_test_direct_encoder_stage/README.md
@@ -1,20 +1,20 @@
-# Direct Encoder Stage Self Test
+# Direct Encoder Stepper Stage Self Test
 
 *By Nathan Paolini*
 
-These are scripts that can be run to allow a Zaber stage with a direct encoder to analyze its own performance.
+These are scripts that can be run with a Zaber stepper motor driven direct encoder stage to allow the stage to analyze its own performance.
 
 ![accuracy_plot.png](img/accuracy_plot.png)
 
 ## Hardware Requirements
 
-A linear or rotary direct encoder stage.
+A linear or rotary direct encoder stepper motor stage.
 
 ## Dependencies / Software Requirements / Prerequisites
 
 The script uses `pdm` to manage virtual environment and dependencies:
 
-Instructions on how to install it can be found on the official `pdm` project page [here](https://github.com/pdm-project/pdm).
+Instructions on how to install it can be found on the official `pdm` [project page](https://github.com/pdm-project/pdm).
 
 The dependencies are listed in `pyproject.toml`.
 
@@ -48,7 +48,7 @@ pdm run settling-time
 
 ## Script Purpose
 
-Zaber stages with direct encoders allow the stage to report on its own performance.
+Zaber stepper motor stages with direct encoders are capable of measuring their own open loop performance.
 
-- `src/self_test_direct_encoder_stage/accuracy.py` allows a direct encoder stage to test it's open loop accuracy or repeatability.
-- `src/self_test_direct_encoder_stage/settling_time.py` allows a direct encoder stage to determine its move-and-settle time for a variety of settings and step sizes.
+- `src/self_test_direct_encoder_stage/accuracy.py` allows a stage to test it's open loop accuracy or repeatability.
+- `src/self_test_direct_encoder_stage/settling_time.py` allows a stage to determine its move-and-settle time for a variety of settings and step sizes.

--- a/examples/self_test_direct_encoder_stage/article.yml
+++ b/examples/self_test_direct_encoder_stage/article.yml
@@ -1,7 +1,7 @@
 authors:
   - Nathan Paolini
 date: 2023-06-10
-updated_date: 2023-06-10
+updated_date: 2026-05-04
 category: Diagnostics
 tags:
   - Python


### PR DESCRIPTION
Some clarifications to the readme to indicate that these scripts are stepper specific and work for digital and analog direct encoders.